### PR TITLE
Add release verification information to website

### DIFF
--- a/core22.md
+++ b/core22.md
@@ -36,6 +36,8 @@ Implementation of the JavaServer™ Faces (JSF) 2.2 specification.
 </dependency>
 ```
 
+[Release Verification](/releaseVerification.md ':include')
+
 ## Configuration
 
 MyFaces core behavior can be customized, adding some web config params into your WEB-INF/web.xml or META-INF/web-fragment.xml file for your custom project in this way:

--- a/core23.md
+++ b/core23.md
@@ -36,6 +36,8 @@ Implementation of the JavaServer™ Faces (JSF) 2.3 specification.
 </dependency>
 ```
 
+[Release Verification](/releaseVerification.md ':include')
+
 ## Configuration
 
 MyFaces core behavior can be customized, adding some web config params into your WEB-INF/web.xml or META-INF/web-fragment.xml file for your custom project in this way:

--- a/core23next.md
+++ b/core23next.md
@@ -52,6 +52,8 @@ What are the disadvantages compared to 2.3?
 </dependency>
 ```
 
+[Release Verification](/releaseVerification.md ':include')
+
 ## Configuration
 
 MyFaces core behavior can be customized, adding some web config params into your WEB-INF/web.xml or META-INF/web-fragment.xml file for your custom project in this way:

--- a/core30.md
+++ b/core30.md
@@ -37,6 +37,8 @@ Implementation of the Jakarta Server Faces 3.0 specification.
 </dependency>
 ```
 
+[Release Verification](/releaseVerification.md ':include')
+
 ## Configuration
 
 MyFaces core behavior can be customized, adding some web config params into your WEB-INF/web.xml or META-INF/web-fragment.xml file for your custom project in this way:

--- a/core40.md
+++ b/core40.md
@@ -38,6 +38,8 @@ What are the benefits compared to our older versions?
 </dependency>
 ```
 
+[Release Verification](/releaseVerification.md ':include')
+
 ## Configuration
 
 MyFaces core behavior can be customized, adding some web config params into your WEB-INF/web.xml or META-INF/web-fragment.xml file for your custom project in this way:

--- a/oldVersions.md
+++ b/oldVersions.md
@@ -9,6 +9,8 @@
 
 [Apache MyFaces Core 1.1](#apache-myfaces-core-11)
 
+[Release Verification](#Verifying-checksums)
+
 [2.1](/core21.md ':include')
 
 [2.0](/core20.md ':include')
@@ -16,3 +18,5 @@
 [1.2](/core12.md ':include')
 
 [1.1](/core11.md ':include')
+
+[Release Verification](/releaseVerification.md ':include')

--- a/releaseVerification.md
+++ b/releaseVerification.md
@@ -1,0 +1,49 @@
+## Verifying checksums
+
+It is essential that you verify the integrity of the downloaded
+files using the PGP and MD5/SHA512 signatures.  MD5/SHA512 verification ensures the
+file was not corrupted during the download process.  PGP verification
+ensures that the file came from a certain person.
+  
+To verify the MD5 signature on the files, you need to use a program
+called _md5_ or _md5sum_, which is
+included in many unix distributions.  It is also available as part of
+[GNU Textutils](http://www.gnu.org/software/textutils/textutils.html).  
+Windows users can get binary md5 programs from [here](http://www.fourmilab.ch/md5/),
+[here](http://www.pc-tools.net/win32/freeware/console/), or
+[here](http://www.slavasoft.com/fsum/).
+
+To verify the SHA512 signature on the files, you need to use a program called
+e.g. _sha, shasum, sha512sum_ which is included in many unix distributions, MacOS
+and Windows.  
+  
+## Verifying signatures
+
+PGP verification ensures that the file came from a certain person.  We strongly recommend 
+you verify your downloads with both PGP and MD5/SHA512.
+ 
+The PGP signatures can be verified using [PGP](http://www.pgpi.org/) or 
+[GPG](http://www.gnupg.org/).  First download the Apache MyFaces 
+[KEYS](https://www.apache.org/dist/myfaces/KEYS) as well as the _asc_ signature file 
+for the particular distribution. It is important that you get these files from the ultimate
+trusted source - the main ASF distribution site, rather than from a mirror.
+Then verify the signatures using:
+
+```
+% pgpk -a KEYS
+% pgpv myfaces-core-X.Y.Z-bin.tar.gz.asc
+```
+	
+_or_
+
+```
+% pgp -ka KEYS
+% pgp myfaces-core-X.Y.Z-bin.tar.gz.asc
+```
+	
+_or_
+
+```
+% gpg --import KEYS
+% gpg --verify myfaces-core-X.Y.Z-bin.tar.gz.asc
+```


### PR DESCRIPTION
As part of the announce to Apache of a new release it was pointed out this was missing. Adding it to try and get the announce though to the mailing list.