### PR TITLE
Add links to release verification

### DIFF
--- a/core11.md
+++ b/core11.md
@@ -14,6 +14,9 @@ Implementation of the JavaServer™ Faces (JSF) 1.1 specification.
 | source (tar.gz) | [myfaces-core-assembly-1.1.10-src.tar.gz](http://www.apache.org/dyn/closer.lua/myfaces/source/myfaces-core-assembly-1.1.10-src.tar.gz)   | [myfaces-core-assembly-1.1.10-src.tar.gz.md5](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-1.1.10-src.tar.gz.md5)   | [myfaces-core-assembly-1.1.10-src.tar.gz.asc](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-1.1.10-src.tar.gz.asc)   |
 | source (zip)    | [myfaces-core-assembly-1.1.10-src.zip](http://www.apache.org/dyn/closer.lua/myfaces/source/myfaces-core-assembly-1.1.10-src.zip)         | [myfaces-core-assembly-1.1.10-src.zip.md5](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-1.1.10-src.zip.md5)         | [myfaces-core-assembly-1.1.10-src.zip.asc](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-1.1.10-src.zip.asc)         |
 
+## Release Verification
+Steps for checksum & signature verification can be found [here](/releaseVerification.md)
+
 ## Dependency
 ```xml
 <dependency>

--- a/core12.md
+++ b/core12.md
@@ -14,6 +14,9 @@ Implementation of the JavaServer™ Faces (JSF) 1.2 specification.
 | source (tar.gz) | [myfaces-core-assembly-1.2.12-src.tar.gz](http://www.apache.org/dyn/closer.lua/myfaces/source/myfaces-core-assembly-1.2.12-src.tar.gz)   | [myfaces-core-assembly-1.2.12-src.tar.gz.md5](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-1.2.12-src.tar.gz.md5)   | [myfaces-core-assembly-1.2.12-src.tar.gz.asc](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-1.2.12-src.tar.gz.asc)   |
 | source (zip)    | [myfaces-core-assembly-1.2.12-src.zip](http://www.apache.org/dyn/closer.lua/myfaces/source/myfaces-core-assembly-1.2.12-src.zip)         | [myfaces-core-assembly-1.2.12-src.zip.md5](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-1.2.12-src.zip.md5)         | [myfaces-core-assembly-1.2.12-src.zip.asc](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-1.2.12-src.zip.asc)         |
 
+## Release Verification
+Steps for checksum & signature verification can be found [here](/releaseVerification.md)
+
 ## Dependency
 ```xml
 <dependency>

--- a/core20.md
+++ b/core20.md
@@ -22,6 +22,9 @@ Implementation of the JavaServer™ Faces (JSF) 2.0 specification.
 | source (tar.gz) | [myfaces-core-assembly-2.0.25-src.tar.gz](http://www.apache.org/dyn/closer.lua/myfaces/source/myfaces-core-assembly-2.0.25-src.tar.gz)   | [myfaces-core-assembly-2.0.25-src.tar.gz.sha512](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-2.0.25-src.tar.gz.sha512)   | [myfaces-core-assembly-2.0.25-src.tar.gz.asc](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-2.0.25-src.tar.gz.asc)   |
 | source (zip)    | [myfaces-core-assembly-2.0.25-src.zip](http://www.apache.org/dyn/closer.lua/myfaces/source/myfaces-core-assembly-2.0.25-src.zip)         | [myfaces-core-assembly-2.0.25-src.zip.sha512](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-2.0.25-src.zip.sha512)         | [myfaces-core-assembly-2.0.25-src.zip.asc](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-2.0.25-src.zip.asc)         |
 
+## Release Verification
+Steps for checksum & signature verification can be found [here](/releaseVerification.md)
+
 ## Dependency
 ```xml
 <dependency>

--- a/core21.md
+++ b/core21.md
@@ -22,6 +22,9 @@ Implementation of the JavaServer™ Faces (JSF) 2.1 specification.
 | source (tar.gz) | [myfaces-core-assembly-2.1.18-src.tar.gz](http://www.apache.org/dyn/closer.lua/myfaces/source/myfaces-core-assembly-2.1.18-src.tar.gz)   | [myfaces-core-assembly-2.1.18-src.tar.gz.md5](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-2.1.18-src.tar.gz.md5)   | [myfaces-core-assembly-2.1.18-src.tar.gz.asc](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-2.1.18-src.tar.gz.asc)   |
 | source (zip)    | [myfaces-core-assembly-2.1.18-src.zip](http://www.apache.org/dyn/closer.lua/myfaces/source/myfaces-core-assembly-2.1.18-src.zip)         | [myfaces-core-assembly-2.1.18-src.zip.md5](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-2.1.18-src.zip.md5)         | [myfaces-core-assembly-2.1.18-src.zip.asc](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-2.1.18-src.zip.asc)         |
 
+## Release Verification
+Steps for checksum & signature verification can be found [here](/releaseVerification.md)
+
 ## Dependency
 ```xml
 <dependency>


### PR DESCRIPTION
The individual older release pages don't include steps for verification. i.e. https://myfaces.apache.org/#/core20

However, https://myfaces.apache.org/#/oldVersions does have the information at the bottom. 

Just adding a link to the verification steps. 

This was requested by the Apache release team for the announcement. 