### PR TITLE
Update release verfication for 2.2-4.0 pages, update checking signature link

### DIFF
--- a/core22.md
+++ b/core22.md
@@ -36,7 +36,8 @@ Implementation of the JavaServer™ Faces (JSF) 2.2 specification.
 </dependency>
 ```
 
-[Release Verification](/releaseVerification.md ':include')
+## Release Verification
+Steps for checksum & signature verification can be found [here](/releaseVerification.md)
 
 ## Configuration
 

--- a/core23.md
+++ b/core23.md
@@ -36,7 +36,8 @@ Implementation of the JavaServer™ Faces (JSF) 2.3 specification.
 </dependency>
 ```
 
-[Release Verification](/releaseVerification.md ':include')
+## Release Verification
+Steps for checksum & signature verification can be found [here](/releaseVerification.md)
 
 ## Configuration
 

--- a/core23next.md
+++ b/core23next.md
@@ -52,7 +52,8 @@ What are the disadvantages compared to 2.3?
 </dependency>
 ```
 
-[Release Verification](/releaseVerification.md ':include')
+## Release Verification
+Steps for checksum & signature verification can be found [here](/releaseVerification.md)
 
 ## Configuration
 

--- a/core30.md
+++ b/core30.md
@@ -37,7 +37,8 @@ Implementation of the Jakarta Server Faces 3.0 specification.
 </dependency>
 ```
 
-[Release Verification](/releaseVerification.md ':include')
+## Release Verification
+Steps for checksum & signature verification can be found [here](/releaseVerification.md)
 
 ## Configuration
 

--- a/core40.md
+++ b/core40.md
@@ -37,7 +37,8 @@ What are the benefits compared to our older versions?
 </dependency>
 ```
 
-[Release Verification](/releaseVerification.md ':include')
+## Release Verification
+Steps for checksum & signature verification can be found [here](/releaseVerification.md)
 
 ## Configuration
 

--- a/releaseVerification.md
+++ b/releaseVerification.md
@@ -34,4 +34,4 @@ Then, to verify the signatures through the gpg command line, use the following c
 % gpg --verify myfaces-core-X.Y.Z-bin.tar.gz.asc myfaces-core-X.Y.Z-bin.tar.gz
 ```
 
-More can be read about verifying downloads [here](https://www.apache.org/info/verification.html#). 
+More can be read about verifying downloads [here](https://www.apache.org/info/verification.html#CheckingSignatures). 


### PR DESCRIPTION
Instead of including the text on each download page, add a link to the releaseVerification page instead. 


Also, for Sebb's request, I  specified a link to the CheckingSignatures section. 