### PR TITLE
Update site for 4.1.0-RC1 release

### DIFF
--- a/core41.md
+++ b/core41.md
@@ -1,14 +1,14 @@
 # Apache MyFaces Core 4.1
 
-Implementation of the Jakarta Faces 4.1 specification.  
+Implementation of the Jakarta Faces 4.1 specification for Jakarta Enterprise Edition 11. 
 
 ## Requirements
-* Java 11
-* Servlet 5.0+
-* EL 5.0
-* CDI 4.0
+* Java 17
+* Servlet 6.1+
+* EL 6.0
+* CDI 4.1
 * JSTL 3.0 (optional)
-* BV 3.0 (optional)
+* BV 3.1 (optional)
 
 ## Source
 [Apache GitBox](https://gitbox.apache.org/repos/asf?p=myfaces.git;a=shortlog;h=refs/heads/master) / [GitHub](https://github.com/apache/myfaces/tree/master)
@@ -17,22 +17,22 @@ Implementation of the Jakarta Faces 4.1 specification.
 
 |     | Mirrors                                                                                                                      | Checksum                                                                                                                     | Signature                                                                                                                                |
 |-----------------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
-| binary (tar.gz) | [myfaces-core-assembly-4.0.1-bin.tar.gz](https://www.apache.org/dyn/closer.lua/myfaces/binaries/myfaces-core-assembly-4.0.1-bin.tar.gz) | [myfaces-core-assembly-4.0.1-bin.tar.gz.sha512](https://downloads.apache.org/myfaces/binaries/myfaces-core-assembly-4.0.1-bin.tar.gz.sha512) | [myfaces-core-assembly-4.0.1-bin.tar.gz.asc](https://downloads.apache.org/myfaces/binaries/myfaces-core-assembly-4.0.1-bin.tar.gz.asc) |
-| binary (zip)    | [myfaces-core-assembly-4.0.1-bin.zip](https://www.apache.org/dyn/closer.lua/myfaces/binaries/myfaces-core-assembly-4.0.1-bin.zip)       | [myfaces-core-assembly-4.0.1-bin.zip.sha512](https://downloads.apache.org/myfaces/binaries/myfaces-core-assembly-4.0.1-bin.zip.sha512)       | [myfaces-core-assembly-4.0.1-bin.zip.asc](https://downloads.apache.org/myfaces/binaries/myfaces-core-assembly-4.0.1-bin.zip.asc)       |
-| source (tar.gz) | [myfaces-core-assembly-4.0.1-src.tar.gz](https://www.apache.org/dyn/closer.lua/myfaces/source/myfaces-core-assembly-4.0.1-src.tar.gz)   | [myfaces-core-assembly-4.0.1-src.tar.gz.sha512](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-4.0.1-src.tar.gz.sha512)   | [myfaces-core-assembly-4.0.1-src.tar.gz.asc](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-4.0.1-src.tar.gz.asc)   |
-| source (zip)    | [myfaces-core-assembly-4.0.1-src.zip](https://www.apache.org/dyn/closer.lua/myfaces/source/myfaces-core-assembly-4.0.1-src.zip)         | [myfaces-core-assembly-4.0.1-src.zip.sha512](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-4.0.1-src.zip.sha512)         | [myfaces-core-assembly-4.0.1-src.zip.asc](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-4.0.1-src.zip.asc)         |
+| binary (tar.gz) | [myfaces-core-assembly-4.1.0-RC1-bin.tar.gz](https://www.apache.org/dyn/closer.lua/myfaces/binaries/myfaces-core-assembly-4.1.0-RC1-bin.tar.gz) | [myfaces-core-assembly-4.1.0-RC1-bin.tar.gz.sha512](https://downloads.apache.org/myfaces/binaries/myfaces-core-assembly-4.1.0-RC1-bin.tar.gz.sha512) | [myfaces-core-assembly-4.1.0-RC1-bin.tar.gz.asc](https://downloads.apache.org/myfaces/binaries/myfaces-core-assembly-4.1.0-RC1-bin.tar.gz.asc) |
+| binary (zip)    | [myfaces-core-assembly-4.1.0-RC1-bin.zip](https://www.apache.org/dyn/closer.lua/myfaces/binaries/myfaces-core-assembly-4.1.0-RC1-bin.zip)       | [myfaces-core-assembly-4.1.0-RC1-bin.zip.sha512](https://downloads.apache.org/myfaces/binaries/myfaces-core-assembly-4.1.0-RC1-bin.zip.sha512)       | [myfaces-core-assembly-4.1.0-RC1-bin.zip.asc](https://downloads.apache.org/myfaces/binaries/myfaces-core-assembly-4.1.0-RC1-bin.zip.asc)       |
+| source (tar.gz) | [myfaces-core-assembly-4.1.0-RC1-src.tar.gz](https://www.apache.org/dyn/closer.lua/myfaces/source/myfaces-core-assembly-4.1.0-RC1-src.tar.gz)   | [myfaces-core-assembly-4.1.0-RC1-src.tar.gz.sha512](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-4.1.0-RC1-src.tar.gz.sha512)   | [myfaces-core-assembly-4.1.0-RC1-src.tar.gz.asc](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-4.1.0-RC1-src.tar.gz.asc)   |
+| source (zip)    | [myfaces-core-assembly-4.1.0-RC1-src.zip](https://www.apache.org/dyn/closer.lua/myfaces/source/myfaces-core-assembly-4.1.0-RC1-src.zip)         | [myfaces-core-assembly-4.1.0-RC1-src.zip.sha512](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-4.1.0-RC1-src.zip.sha512)         | [myfaces-core-assembly-4.1.0-RC1-src.zip.asc](https://downloads.apache.org/myfaces/source/myfaces-core-assembly-4.1.0-RC1-src.zip.asc)         |
 
 ## Dependency
 ```xml
 <dependency>
   <groupId>org.apache.myfaces.core</groupId>
   <artifactId>myfaces-api</artifactId>
-  <version>4.1.0-SNAPSHOT</version>
+  <version>4.1.0-RC1</version>
 </dependency>
 <dependency>
   <groupId>org.apache.myfaces.core</groupId>
   <artifactId>myfaces-impl</artifactId>
-  <version>4.1.0-SNAPSHOT</version>
+  <version>4.1.0-RC1</version>
 </dependency>
 ```
 
@@ -172,7 +172,7 @@ MyFaces core behavior can be customized, adding some web config params into your
 | ---- | ---- | ---- | ---- | ---- |
 | jakarta.faces.STATE_SAVING_METHOD| 1.1| server| server,client| Define the state method to be used. There are two different options " + "defined by the specification: 'client' and 'server' state.|
 | jakarta.faces.FULL_STATE_SAVING_VIEW_IDS| 2.0| | | Indicate the viewId(s) separated by commas that should be saved and restored fully, without use Partial State Saving (PSS)|
-| jakarta.faces.PARTIAL_STATE_SAVING| 2.0| true (false with 1.2 webapps)| true,false| Enable or disable partial state saving algorithm|
+| jakarta.faces.PARTIAL_STATE_SAVING| 2.0| true (false with 1.2 webapps)| true,false| Enable or disable partial state saving algorithm. Note: Full State Saving is deprecated in 4.1|
 | jakarta.faces.SERIALIZE_SERVER_STATE| 2.2| false| true,false| Indicate if the state should be serialized before save it on the session|
 | o.a.m.USE_ENCRYPTION| 1.1| true| true,false| Indicate if the view state is encrypted or not|
 | o.a.m.SECRET| 1.1| | | Defines the secret (Base64 encoded) used to initialize the secret key for encryption algorithm|

--- a/news.md
+++ b/news.md
@@ -1,5 +1,10 @@
 # News
 
+##  January 29, 2024 - MyFaces Core 4.1.0-RC1 released
+MyFaces Core 4.1.0-RC1 have been released. It is available from the [Download](/core41?id=downloads) page, and in the central Maven repository under Group ID "org.apache.myfaces.core".
+
+Release notes can be found here: [4.1.0-RC1](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=10600&version=12353454)
+
 ##  May 24, 2023 - MyFaces Core 4.0.1 released
 MyFaces Core 4.0.1 have been released. It is available from the [Download](/core40?id=downloads) page, and in the central Maven repository under Group ID "org.apache.myfaces.core".
 


### PR DESCRIPTION
Only property change I noticed:
 - FACELETS_REFRESH_PERIOD (production is -1 which is already labelled correctly)
 - jakarta.faces.PARTIAL_STATE_SAVING is deprecated since FSS will be removed. 
 