### PR TITLE
fix: Add required ASF policy links to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,16 @@
           var footer = [
             '<hr/>',
             '<footer>',
-            '   <p>Copyright © 2002-2025 The Apache Software Foundation, Licensed under the Apache License, Version 2.0.</p>\n',
-            '   <p>Apache MyFaces, Apache Tobago, Apache, the Apache feather logo, and the Apache MyFaces project logos are trademarks of The Apache Software Foundation.</p>',
+            '   <p>Copyright &copy; 2002-2026 The Apache Software Foundation, Licensed under the ',
+            '   <a href="https://www.apache.org/licenses/">Apache License, Version 2.0</a>.</p>\n',
+            '   <p>Apache MyFaces, Apache Tobago, Apache, the Apache feather logo, and the Apache MyFaces project logos are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</p>',
+            '   <p><a href="https://www.apache.org/">Foundation</a> | ',
+            '   <a href="https://www.apache.org/events/current-event.html">Events</a> | ',
+            '   <a href="https://www.apache.org/licenses/">License</a> | ',
+            '   <a href="https://www.apache.org/security/">Security</a> | ',
+            '   <a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> | ',
+            '   <a href="https://www.apache.org/foundation/thanks.html">Thanks</a> | ',
+            '   <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a></p>',
             '</footer>'
           ].join('');
 


### PR DESCRIPTION
The MyFaces website is missing several links required by ASF website policy (https://whimsy.apache.org/site/):

- Foundation link (apache.org)
- Events
- License (was text-only, now linked)
- Security
- Sponsorship
- Thanks
- Privacy

This updates the Docsify footer plugin in index.html to include all required ASF policy links, updates copyright year to 2026, and links the license text to the canonical URL.

See: https://www.apache.org/foundation/marks/pmcs
Checker: https://whimsy.apache.org/site/

# If this PR is for a release, please review the checklist:

- [ ] Update the news.md
- [ ] Update the core version page (e.g., core40.md, core41.md)
- [ ] Review any context parameter changes
- [ ] Ensure all the links work (downloads and release notes)